### PR TITLE
fix(integration): add type import for DID

### DIFF
--- a/integration.ts
+++ b/integration.ts
@@ -1,6 +1,7 @@
 // Don't forget to rebuild
 import { createIDX } from "./idx";
 import type { CeramicApi } from "@ceramicnetwork/common";
+import type { DID } from 'dids';
 import { _encryptWithLit, _decryptWithLit } from "./lit";
 import { _startLitClient } from "./client";
 import {


### PR DESCRIPTION
Was breaking webpack build with our tsconfig

![image](https://user-images.githubusercontent.com/30693990/152326729-4ab2dc31-5c0d-476c-9a4a-a683758f44c9.png)


```json
//tsconfig.json

{
  "compileOnSave": false,
  "compilerOptions": {
    "module": "esnext",
    "typeRoots": [
      "./node_modules/@types"
    ],
    "removeComments": true,
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "allowSyntheticDefaultImports": true,
    "sourceMap": true,
    "target": "es2019",
    "lib": [
      "es2019",
      "dom"
    ],
    "moduleResolution": "node",
    "baseUrl": "src",
    "resolveJsonModule": true,
    "allowJs": true
  },
  "include": [
    "src",
    "test"
  ],
  "exclude": [
    "test/coverage-jest"
  ],
  "atom": {
    "rewriteTsconfig": false
  }
}

```